### PR TITLE
Add Vale linting hook for Markdown files

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 writing-tools/hooks/vale_lint.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/writing-tools/hooks/hooks.json
+++ b/writing-tools/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/vale_lint.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/writing-tools/hooks/vale_lint.py
+++ b/writing-tools/hooks/vale_lint.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""PostToolUse hook: run Vale on edited or written Markdown files."""
+
+import json
+import subprocess
+import sys
+
+
+def main():
+    hook_input = json.loads(sys.stdin.read())
+    tool_input = hook_input.get("tool_input", {})
+    file_path = tool_input.get("file_path", "")
+
+    if not file_path:
+        return
+
+    if not file_path.endswith(".md"):
+        return
+
+    result = subprocess.run(
+        ["vale", file_path],
+        capture_output=True,
+        text=True,
+    )
+
+    if result.returncode != 0 and result.stdout:
+        print(json.dumps({
+            "result": "Vale found issues",
+            "description": result.stdout.strip(),
+        }), file=sys.stderr)
+    elif result.returncode == 0:
+        print(json.dumps({
+            "result": "Vale passed",
+            "description": f"No issues found in {file_path}",
+        }))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
This PR adds a PostToolUse hook that automatically runs Vale (a prose linter) on Markdown files after they are edited or written by Claude.

## Key Changes
- **vale_lint.py**: New Python script that serves as a PostToolUse hook to lint Markdown files
  - Reads tool input from stdin to extract the file path
  - Runs Vale on `.md` files only
  - Reports linting results via stdout/stderr in JSON format
  - Distinguishes between Vale passing (no issues) and failing (issues found)

- **hooks.json**: New hook configuration file
  - Registers the Vale linting hook to run after Write or Edit operations
  - Configures the hook to execute the Python script via the plugin root

## Implementation Details
- The hook only processes files with `.md` extension to avoid unnecessary linting
- Vale output is captured and formatted as JSON for structured feedback
- Issues are reported to stderr while success messages go to stdout
- The hook gracefully handles missing file paths by returning early

https://claude.ai/code/session_01FzGyvQjv1DpezhdKRPhoVn