### PR TITLE
Add official Claude plugins marketplace and enable plugin-dev

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,15 @@
 {
+  "extraKnownMarketplaces": {
+    "claude-plugins-official": {
+      "source": {
+        "source": "github",
+        "repo": "anthropics/claude-plugins-official"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "plugin-dev@claude-plugins-official": true
+  },
   "hooks": {
     "PostToolUse": [
       {


### PR DESCRIPTION
## Summary
This change configures the Claude environment to recognize and use the official Claude plugins marketplace from Anthropic's GitHub repository, and enables the plugin development plugin.

## Key Changes
- Added `extraKnownMarketplaces` configuration to register the official Claude plugins marketplace (`claude-plugins-official`) sourced from the `anthropics/claude-plugins-official` GitHub repository
- Enabled the `plugin-dev` plugin from the official marketplace in the `enabledPlugins` configuration

## Implementation Details
The configuration adds a new marketplace source that points to Anthropic's official plugins repository on GitHub, allowing access to officially maintained plugins. The `plugin-dev` plugin is explicitly enabled to support plugin development workflows.

https://claude.ai/code/session_0191uLu2mFZXKK3QDCRZGBuc